### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://igdexe.visualstudio.com/07d08f9e-e61e-4dbd-9f58-36ef2691886f/9b8e4c0d-04c8-43d6-89a8-31b57a8b721a/_apis/work/boardbadge/e0a1d128-5c17-46ab-a79e-885bf4155eff)](https://igdexe.visualstudio.com/07d08f9e-e61e-4dbd-9f58-36ef2691886f/_boards/board/t/9b8e4c0d-04c8-43d6-89a8-31b57a8b721a/Microsoft.RequirementCategory)
 # Microsoft-Community


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://igdexe.visualstudio.com/07d08f9e-e61e-4dbd-9f58-36ef2691886f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.